### PR TITLE
feat: addresses minor bugs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.github/workflows/update_registry.yml
+++ b/.github/workflows/update_registry.yml
@@ -16,9 +16,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       
-      - name: Setup MSVC Environment
-        uses: ilammy/msvc-dev-cmd@v1.12.1
-        
       - name: Setup VCPKG
         uses: lukka/run-vcpkg@v11
         with:
@@ -27,13 +24,13 @@ jobs:
       - name: Update Registry
         id: registry
         shell: pwsh
-        run: "& ${{ github.workspace }}/.github/update-registry.ps1"
+        run: "& ${{ github.workspace }}/.github/update-registry.ps1 ${{ github.event.client_payload.sha }}"
 
       - name: Check for Commit
-        if: ${{ steps.registry.outputs.VCPKG_SUCCESS == 'true' }}
+        if: ${{ steps.registry.outputs.VCPKG_SUCCESS }} == 'true'
         uses: EndBug/add-and-commit@v9
         with:
           author_name: vcpkg-action
-          message: "build: update registry"
+          message: "docs: update registry"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
1. Fixes the REF collision (or rather, fails with clearer error statement).
2. Fixes the version entry collision, new collide version entry of the same verison-date will be appended with a numeric disambiguation identifier, incremental.
3. Moved `vcersions/baseline.json` file change to `port: version-date` commit, to distinguish from the follow up commit of `docs: update registry`
4. `docs: update registry` will update the workflow yaml with the latest vcpkg commit as well.

---
closes #2 