### PR TITLE
fix: change to githubaction bot for bot commits

### DIFF
--- a/.github/update-registry.ps1
+++ b/.github/update-registry.ps1
@@ -125,7 +125,7 @@ vcpkg_from_github(
     # update version entries
     Write-Host "Propagating version entry..."
     $gitlog = & git config user.name "vcpkg-action"
-    $gitlog += & git config user.email "gottyduke@hotmail.com"
+    $gitlog += & git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
     $gitlog += & git commit -am "port: check"
     $tree = & git rev-parse HEAD:ports/commonlibsf
     $gitlog += $tree

--- a/.github/workflows/update_registry.yml
+++ b/.github/workflows/update_registry.yml
@@ -31,6 +31,7 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           author_name: vcpkg-action
+          author_email: 41898282+github-actions[bot]@users.noreply.github.com
           message: "chore: update registry"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Change user.email to use github actions bot instead for workflow commits. Check here for choice of email https://github.com/orgs/community/discussions/26560

Before (Hardcoded to gottyduke for port, then the triggerer of workflow for the chore commit):
![image](https://github.com/Starfield-Reverse-Engineering/Starfield-RE-vcpkg/assets/964655/afb8c299-93b0-4694-8ff1-5af4a691c166)
After PR:
![image](https://github.com/Starfield-Reverse-Engineering/Starfield-RE-vcpkg/assets/964655/60f2a216-289e-4823-b2b2-86b1ba19bbc9)

This makes is much clearer that these two commits were done by a bot