### PR TITLE
ci: update chore commit to only be committed by bot

### DIFF
--- a/.github/workflows/update_registry.yml
+++ b/.github/workflows/update_registry.yml
@@ -30,8 +30,6 @@ jobs:
         if: ${{ steps.registry.outputs.VCPKG_SUCCESS }} == 'true'
         uses: EndBug/add-and-commit@v9
         with:
-          author_name: vcpkg-action
-          author_email: 41898282+github-actions[bot]@users.noreply.github.com
+          committer_name: vcpkg-action
+          committer_email: 41898282+github-actions[bot]@users.noreply.github.com
           message: "chore: update registry"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This will change so the bot is not the "author" only the "committer" of the chore commit. 

Before:
![image](https://github.com/Starfield-Reverse-Engineering/Starfield-RE-vcpkg/assets/964655/cfca30d1-97c9-4247-b876-bd2fbac24f23)

After (This is from the `Starfield-Reverse-Engineering/CommonLibSF` repo, but same concept, did not change commit message):
![image](https://github.com/Starfield-Reverse-Engineering/Starfield-RE-vcpkg/assets/964655/984af046-dd97-4d3e-9c8d-bc9571493932)
