### PR TITLE
fix: update vcpkg registry

### DIFF
--- a/.github/workflows/update_registry.yml
+++ b/.github/workflows/update_registry.yml
@@ -15,7 +15,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+        with:
+          token: ${{ secrets.VCPKG_HELPER_TOKEN }}
+
       - name: Setup VCPKG
         uses: lukka/run-vcpkg@v11
         with:


### PR DESCRIPTION
fixed #9

FYI the `VCPKG_HELPER_TOKEN` needs to setup like this for this to work:
![image](https://github.com/Starfield-Reverse-Engineering/Starfield-RE-vcpkg/assets/964655/c89cc268-fe9c-4c23-a0dc-e7fe7fdebdae)

So this PR was only tested on my fork with a new classic token set with that permission